### PR TITLE
Changes:

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ eg
 
     npm-delegate -p 1337 http://localhost:5984/registry https://registry.npmjs.org
 
+use cluster as a running platform
+
+    npm-delegate --cluster --threshold 3000 -p 1337 http://localhost:5984/registry https://registry.npmjs.org
+
+Note: --threshold option specifies the max number of connection after which the cluster worker will be recycled, default is 3000.
+
+use timeout and retry in case of timeout
+
+    npm-delegate --retry 3 --timeout 10000 -p 1337 http://localhost:5984/registry https://registry.npmjs.org
+
 setup your npm client:
 
     npm do-some-stuff --registry http://your-delegate-host:1337

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,6 +8,14 @@ var optimist = require('optimist')
   .alias('p','port')
   .default('p',5983)
   .describe('p', 'port to listen on')
+  .alias('r','retry')
+  .default('r', 0)
+  .describe('r', 'retry count in case of timeout')
+  .default('timeout',3000)
+  .describe('timeout', 'connection timeout')
+  .alias('t','threshold')
+  .default('t', 3000)
+  .describe('t', 'connection threshold, when reached, the cluster worker will be recycled')
   .alias('s','secure')
   .boolean('s')
   .default('s', false)
@@ -17,6 +25,9 @@ var optimist = require('optimist')
   .boolean('strictssl')
   .default('strictssl', true)
   .describe('strictssl', 'only accept https certificates from known authorities (turn off with no-strictssl)')
+  .boolean('cluster')
+  .default('cluster', false)
+  .describe('cluster', 'use cluster as a runnning platform')
   .check(function (argv) {
     if (!argv._.length)
       throw new Error('you must specify at least one registry (two to be useful)')
@@ -25,7 +36,24 @@ var optimist = require('optimist')
 
 var proxy = argv.proxy || process.env.http_proxy;
 
-(argv.secure ? https : http).createServer(
-  delegate(argv._, proxy, argv.strictssl)
-).listen(argv.port);
+var server = (argv.secure ? https : http).createServer(
+  delegate(argv._, proxy, argv.strictssl, {retry: argv.retry, timeout: argv.timeout})
+);
+
+if (argv.cluster) {
+  var Cluster = require('cluster2');
+
+  var c = new Cluster({
+      port: argv.port,
+      connThreshold: argv.thershold || 3000
+  });
+  c.listen(function(cb) {
+      cb(server);
+  });
+  console.log("Running cluster... ");
+}
+else {
+  server.listen(argv.port);  
+}
+
 console.log("npm-delegate listening on port ", argv.port);

--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -14,9 +14,10 @@ function debug() {
   }
 }
 
-module.exports = function setup(registryUrls, proxy, strictSSL) {
+module.exports = function setup(registryUrls, proxy, strictSSL, options) {
   var registries = registryUrls.map(parseRegistry);
 
+  options = options || {};
   if (proxy) {
     debug("Using proxy: ", proxy);
   }
@@ -39,7 +40,7 @@ module.exports = function setup(registryUrls, proxy, strictSSL) {
 
     fallback(
       registries, 
-      forwardReq(req, proxy, strictSSL), 
+      forwardReq(req, proxy, strictSSL, options), 
       function (err, resIn, registry) {
         if (err) {
           debug("Err was ", err);
@@ -64,20 +65,32 @@ module.exports = function setup(registryUrls, proxy, strictSSL) {
           debug("setting header");
           resOut.setHeader('x-registry', url.format(registry))
           debug("piping to output");
+
           resIn.pipe(resOut);
+          resIn.on('error', function(err) {
+            resOut.statusCode = 400
+            resOut.write(
+              JSON.stringify({
+                error: 'There was an error resolving your request:\n' + JSON.stringify(err, null, 2)
+              })
+            )
+            //resOut.connection.destroy();
+            resOut.destroy();
+            debug('Got error during streaming: ' + (err.stack || err));
+          });
         }
     });
     
   };
 };
 
-function forwardReq(request, proxy, strictSSL) {
+function forwardReq(request, proxy, strictSSL, options) {
   return function(registry, cb) {
-    forward(request, registry, proxy, strictSSL, cb);
+    forward(request, registry, proxy, strictSSL, options, cb);
   }
 }
 
-function forward(reqIn, registry, proxy, strictSSL, cb) {
+function forward(reqIn, registry, proxy, strictSSL, options, cb) {
   var reqOut = {
     protocol: registry.protocol
     , hostname: registry.hostname
@@ -87,18 +100,24 @@ function forward(reqIn, registry, proxy, strictSSL, cb) {
   
   debug('fwd req', reqOut)
 
+  reqIn.headers.target = reqIn.headers.host;
   delete reqIn.headers.host;
   delete reqIn.headers.authorization;
 
-  lookBeforeYouLeap(
-    { 
+  var params = { 
       url: url.format(reqOut), 
       method: reqIn.method, 
       headers: reqIn.headers, 
       auth: registry.auth,
       proxy: proxy,
-      strictSSL: strictSSL
-    }, 
+      strictSSL: strictSSL,
+      timeout: options.timeout || 30000,
+      retry: options.retry || 0,
+      retryCount: 0
+    };
+
+  lookBeforeYouLeap(
+    params, 
     function (err, res) {
       if (err) {
         debug("Error talking to %s, was: ", registry.hostname, err);
@@ -127,12 +146,24 @@ function lookBeforeYouLeap(params, cb) {
     debug("HEAD %s returned %d", params.url, res && res.statusCode);
     //nothing useful
     if (err || (res && res.statusCode >= 400)) {
+        
+      if (err && /TIMEDOUT$/.test(err.code) 
+          && params.retryCount++ <= params.retry) {
+  
+          debug("Got timeout will retry for: " + params.url);
+          // retry
+          process.nextTick(function() {
+            lookBeforeYouLeap(params, cb);
+          });
+          return;
+      }
+
       return cb(err, res);
     }
     //we've got a useful response
     //make a get request
     debug("GET ", params.url);
-    params.method = "GET";
+    params.method = "GET"; 
     return cb(null, request(params));
   });
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "scripts": {
     "test": "mocha -R spec"
   },
+  "scripts": {
+    "test": "mocha --ui bdd --reporter spec  ./test"
+  },  
   "keywords": [
     "npm",
     "registry",
@@ -24,7 +27,8 @@
     "optimist": "~0.3.5",
     "fallback": "~1.0.0",
     "url2": "0.0.0",
-    "request": "~2.21.0"
+    "request": "~2.21.0",
+    "cluster2": "0.4.15"
   },
   "devDependencies": {
     "should": "~1.2.2",

--- a/test/negative-test.js
+++ b/test/negative-test.js
@@ -1,0 +1,149 @@
+var http = require('http')
+, should = require('should')
+, child_process = require('child_process')
+, path = require('path')
+, request = require('request')
+, path = require('path')
+, delegate = require('../lib/delegate');
+
+describe('npm-delegate negative', function() {
+	
+	process.env['NODE_DEBUG'] = 'npm-delegate';
+
+	var badServer;
+	var server;
+	var allowHead = true;
+	before(function(done) {
+		badServer = http.createServer(function(req, res) {
+			// no response
+			if (allowHead && req.method === 'HEAD') {
+				res.writeHead(200);
+				res.end();
+			}
+		});
+		badServer.listen(8090);
+
+		server = http.createServer(
+			delegate(
+		  		['http://localhost:8090/'], null, false, {
+				timeout: 1000,
+				retry: 2
+			}));
+		server.listen(9090);
+
+		done();
+	});
+
+	after(function() {
+		badServer.close();
+		server.close();
+	})
+
+	it('should handle timeout and retry when server is not responsive to HEAD request on check before you leap', function(done) {
+		this.timeout(10000);
+		allowHead = false;
+
+		request('http://localhost:9090/thing', function(err, res, body) {
+			if (err) {
+				done(err);
+				return;
+			}
+			body.should.include("error"); 
+			done();
+		});
+
+	});
+
+	it('should handle timeout when server is not responsive to GET request during streaming', function(done) {
+		this.timeout(10000);
+		allowHead = true;
+
+		request('http://localhost:9090/thing', function(err, res, body) {
+			if (err) {
+				done(err);
+				return;
+			}
+			body.should.include('TIMEDOUT');
+			done();
+		});
+
+	});
+
+});
+
+describe('npm-delegate negative+positive', function() {
+	
+	process.env['NODE_DEBUG'] = 'npm-delegate';
+
+	var badServer, goodServer;
+	var server;
+	var allowHead = true;
+	before(function(done) {
+		badServer = http.createServer(function(req, res) {
+			// no response
+			if (allowHead && req.method === 'HEAD') {
+				res.writeHead(200);
+				res.end();
+			}
+		});
+		badServer.listen(8090);
+
+		goodServer = http.createServer(function(req, res) {
+			// no response
+			res.writeHead(200);
+			if (req.method === 'HEAD') {
+				res.end();
+			}
+			res.end('you got it');
+		});
+		goodServer.listen(8091);
+
+		server = http.createServer(
+			delegate(
+		  		['http://localhost:8090/', 'http://localhost:8091/'], null, false, {
+				timeout: 1000,
+				retry: 2
+			}));
+		server.listen(9090);
+
+		done();
+	});
+
+	after(function() {
+		badServer.close();
+		goodServer.close();
+		server.close();
+	})
+
+	it('should handle timeout and retry when server is not responsive to HEAD request on check before you leap', function(done) {
+		this.timeout(10000);
+		allowHead = false;
+
+		request('http://localhost:9090/thing', function(err, res, body) {
+			if (err) {
+				done(err);
+				return;
+			}
+			res.statusCode.should.be.equal(200);
+			body.should.include('you got it');
+			done();
+		});
+
+	});
+
+	it('should handle timeout when server is not responsive to GET request during streaming', function(done) {
+		this.timeout(10000);
+		allowHead = true;
+
+		request('http://localhost:9090/thing', function(err, res, body) {
+			if (err) {
+				done(err);
+				return;
+			}
+			console.log(body);
+			done();
+		});
+
+	});
+
+});


### PR DESCRIPTION
- cluster support
- error handling at start and during streaming
- timeout to avoid run on sockets when server doesn't respond
- retry logic
- unit tests demostrating the problems being fixed above
- added a small change to preserve npm-delegate host into headers.target attributes; this is useful when one needs to format tarball urls in couchdb show script as pointing to npm-delgate when couchdb is under firewall and only npm-delegate can access it.
